### PR TITLE
Рюкзак контрабандиста, событие Скрытое послание, Респрайт Радио-аплинка, Агосты могут носить перчатки и обувь

### DIFF
--- a/Resources/Locale/ru-RU/evin/station-events/smuggler-satchels.ftl
+++ b/Resources/Locale/ru-RU/evin/station-events/smuggler-satchels.ftl
@@ -1,0 +1,5 @@
+station-event-smuggler-satchel-announcement = Обнаружено несанкционированное использование технологии bluespace.
+
+uplink-gondola-desc = Ящик, содержащий одну стандартную гондолу.
+uplink-smuggler-satchel-name = Сумка контрабандиста
+uplink-smuggler-satchel-desc = Сумка, которую можно спрятать под половицами

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -92,5 +92,6 @@
   contrabandInventory:
     ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1
+    ClothingBackpackSatchelSmuggler: 1 # evin - adding smuggler's satchel to contraband inventory
     ClothingUniformJumpskirtTacticool: 1
   # DO NOT ADD MORE, USE UNIFORM DYING

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -73,9 +73,11 @@
   suffix: Empty
   components:
   - type: Sprite
-    sprite: Objects/Devices/communication.rsi
+    sprite: _Evin/Objects/Specific/boardsyndicat.rsi
     layers:
-    - state: old-radio
+     - state: uplink-syndicate
+     - state: screen-syndicate
+       shader: unshaded
   - type: Item
     sprite: Objects/Devices/communication.rsi
     heldPrefix: old-radio

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -32,3 +32,20 @@
       uiWindowPos: 0,1
       strippingWindowPos: 1,1
       displayName: Mask
+
+ # Kira wants ghost socks
+    - name: shoes
+      slotTexture: shoes
+      slotFlags: FEET
+      stripTime: 3
+      uiWindowPos: 1,0
+      strippingWindowPos: 1,3
+      displayName: Shoes
+
+  # Durk wants ghost gloves    
+    - name: gloves
+      slotTexture: gloves
+      slotFlags: GLOVES
+      uiWindowPos: 2,1
+      strippingWindowPos: 2,2
+      displayName: Gloves  

--- a/Resources/Prototypes/_Evin/Catalog/Fills/Crates/Backpack/smugglerSatchel.yml
+++ b/Resources/Prototypes/_Evin/Catalog/Fills/Crates/Backpack/smugglerSatchel.yml
@@ -11,74 +11,52 @@
 
       - id: null
         prob: 0.7
-        orGroup: gloves
       - id: ClothingHandsGlovesColorYellow
         prob: 0.29
-        orGroup: gloves
       - id: ClothingHandsGlovesCombat
         prob: 0.01
-        orGroup: gloves
 
       - id: null
         prob: 0.5
-        orGroup: gasMask
       - id: ClothingMaskGasExplorer
         prob: 0.2
-        orGroup: gasMask
       - id: ClothingMaskGasAtmos
         prob: 0.2
-        orGroup: gasMask
       - id: ClothingMaskGasSyndicate
         prob: 0.1
-        orGroup: gasMask
 
       - id: null
         prob: 0.2
-        onGroup: tools
       - id: PowerCellHigh
         prob: 0.5
-        onGroup: tools
       - id: JawsOfLife
         prob: 0.1
-        onGroup: tools
       - id: PowerDrill
         prob: 0.1
-        onGroup: tools
       - id: WelderExperimental
         prob: 0.1
-        onGroup: tools
 
       - id: null
         prob: 0.6
-        onGroup: material
       - id: SheetUranium
         prob: 0.1
-        onGroup: material
       - id: IngotGold
         prob: 0.1
-        onGroup: material
       - id: IngotSilver
         prob: 0.1
-        onGroup: material
       - id: MaterialBananium        # use a geigercounter to find the satchel
         prob: 0.1
-        onGroup: material
 
       - id: MedkitCombatFilled
         prob: 0.1
-        onGroup: Medecine
       - id: PillAmbuzol             # cant change the round in a meaningfull way
         prob: 0.1
-        onGroup: Medecine
       - id: CognizineChemistryBottle
         prob: 0.1
-        onGroup: Medecine
       - id: CigPackSyndicate
         prob: 0.1
-        onGroup: Medecine
       - id: StimpackMini
         prob: 0.1
-        onGroup: Medecine
 
       - id: ClothingShoesGaloshes
         prob: 0.1

--- a/Resources/Prototypes/_Evin/Catalog/Fills/Crates/Backpack/smugglerSatchel.yml
+++ b/Resources/Prototypes/_Evin/Catalog/Fills/Crates/Backpack/smugglerSatchel.yml
@@ -1,0 +1,125 @@
+# GoobStation - fill smuggler's satchel whit loot
+# adds more randomness
+# TODO : balance , make groups
+- type: entity
+  parent: ClothingBackpackSatchelSmugglerAnchored
+  id: ClothingBackpackSatchelSmugglerAnchoredFilled
+  suffix: smugglers-anchored-filled
+  components:
+  - type: StorageFill
+    contents:
+
+      - id: null
+        prob: 0.7
+        orGroup: gloves
+      - id: ClothingHandsGlovesColorYellow
+        prob: 0.29
+        orGroup: gloves
+      - id: ClothingHandsGlovesCombat
+        prob: 0.01
+        orGroup: gloves
+
+      - id: null
+        prob: 0.5
+        orGroup: gasMask
+      - id: ClothingMaskGasExplorer
+        prob: 0.2
+        orGroup: gasMask
+      - id: ClothingMaskGasAtmos
+        prob: 0.2
+        orGroup: gasMask
+      - id: ClothingMaskGasSyndicate
+        prob: 0.1
+        orGroup: gasMask
+
+      - id: null
+        prob: 0.2
+        onGroup: tools
+      - id: PowerCellHigh
+        prob: 0.5
+        onGroup: tools
+      - id: JawsOfLife
+        prob: 0.1
+        onGroup: tools
+      - id: PowerDrill
+        prob: 0.1
+        onGroup: tools
+      - id: WelderExperimental
+        prob: 0.1
+        onGroup: tools
+
+      - id: null
+        prob: 0.6
+        onGroup: material
+      - id: SheetUranium
+        prob: 0.1
+        onGroup: material
+      - id: IngotGold
+        prob: 0.1
+        onGroup: material
+      - id: IngotSilver
+        prob: 0.1
+        onGroup: material
+      - id: MaterialBananium        # use a geigercounter to find the satchel
+        prob: 0.1
+        onGroup: material
+
+      - id: MedkitCombatFilled
+        prob: 0.1
+        onGroup: Medecine
+      - id: PillAmbuzol             # cant change the round in a meaningfull way
+        prob: 0.1
+        onGroup: Medecine
+      - id: CognizineChemistryBottle
+        prob: 0.1
+        onGroup: Medecine
+      - id: CigPackSyndicate
+        prob: 0.1
+        onGroup: Medecine
+      - id: StimpackMini
+        prob: 0.1
+        onGroup: Medecine
+
+      - id: ClothingShoesGaloshes
+        prob: 0.1
+      - id: ClothingMaskClown
+        prob: 0.3
+      - id: ClothingHeadPyjamaSyndicateBlack
+        prob: 0.3
+      - id: CyberPen
+        prob: 0.1
+      - id: NukeDiskFake
+        prob: 0.1
+      - id: SoapSyndie
+        prob: 0.1
+      - id: HappyHonkNukieSnacks
+        prob: 0.1
+      - id: RevolverCapGun
+        prob: 0.3
+      - id: ClothingHeadHatCatEars
+        prob: 0.01
+      - id: ResearchDisk10000
+        prob: 0.1
+      - id: CrewMonitoringComputerCircuitboard
+        prob: 0.1
+      - id: SoapOmega
+        prob: 0.1
+
+        #Dangerus items
+
+      - id: SmokeGrenade            # can be made by chemist. thief item
+        prob: 0.1
+      - id: Telecrystal1            # can be found in salvage
+        prob: 0.1
+      - id: Telecrystal10           # can be found in salvage
+        prob: 0.01
+      - id: SyndicatePersonalAI     # is in usless tab, thief item
+        prob: 0.1
+      - id: GatfruitSeeds           # can be obtained from anomaly
+        prob: 0.1
+      - id: ThrowingKnife           # single knife can be found in some boot
+        prob: 0.1
+      - id: DehydratedSpaceCarp     # can be found by salvage
+        prob: 0.01
+
+

--- a/Resources/Prototypes/_Evin/Catalog/Fills/Crates/Backpack/smugglerSatchel.yml
+++ b/Resources/Prototypes/_Evin/Catalog/Fills/Crates/Backpack/smugglerSatchel.yml
@@ -8,14 +8,12 @@
   components:
   - type: StorageFill
     contents:
-
       - id: null
         prob: 0.7
       - id: ClothingHandsGlovesColorYellow
         prob: 0.29
       - id: ClothingHandsGlovesCombat
         prob: 0.01
-
       - id: null
         prob: 0.5
       - id: ClothingMaskGasExplorer
@@ -24,9 +22,6 @@
         prob: 0.2
       - id: ClothingMaskGasSyndicate
         prob: 0.1
-
-      - id: null
-        prob: 0.2
       - id: PowerCellHigh
         prob: 0.5
       - id: JawsOfLife
@@ -35,7 +30,6 @@
         prob: 0.1
       - id: WelderExperimental
         prob: 0.1
-
       - id: null
         prob: 0.6
       - id: SheetUranium
@@ -46,7 +40,6 @@
         prob: 0.1
       - id: MaterialBananium        # use a geigercounter to find the satchel
         prob: 0.1
-
       - id: MedkitCombatFilled
         prob: 0.1
       - id: PillAmbuzol             # cant change the round in a meaningfull way
@@ -57,7 +50,6 @@
         prob: 0.1
       - id: StimpackMini
         prob: 0.1
-
       - id: ClothingShoesGaloshes
         prob: 0.1
       - id: ClothingMaskClown
@@ -82,9 +74,6 @@
         prob: 0.1
       - id: SoapOmega
         prob: 0.1
-
-        #Dangerus items
-
       - id: SmokeGrenade            # can be made by chemist. thief item
         prob: 0.1
       - id: Telecrystal1            # can be found in salvage
@@ -99,5 +88,3 @@
         prob: 0.1
       - id: DehydratedSpaceCarp     # can be found by salvage
         prob: 0.01
-
-

--- a/Resources/Prototypes/_Evin/Catalog/uplink_nomad.yml
+++ b/Resources/Prototypes/_Evin/Catalog/uplink_nomad.yml
@@ -10,3 +10,13 @@
     Telecrystal: 4
   categories:
   - UplinkWearables
+  
+- type: listing
+  id: UplinkClothingBackpackSatchelSmuggler
+  name: uplink-smuggler-satchel-name
+  description: uplink-smuggler-satchel-desc
+  productEntity: ClothingBackpackSatchelSmuggler
+  cost:
+    Telecrystal: 1
+  categories:
+    - UplinkWearables

--- a/Resources/Prototypes/_Evin/Entities/Clothing/Back/smugglersSatchel.yml
+++ b/Resources/Prototypes/_Evin/Entities/Clothing/Back/smugglersSatchel.yml
@@ -1,0 +1,25 @@
+# GoobStation - added smuggler's satchel can be hidden under floorboerds
+- type: entity
+  parent: ClothingBackpackSatchel
+  id: ClothingBackpackSatchelSmuggler
+  name: ранец
+  suffix: smugglers
+  description: Подозрительного вида сумка.
+  components:
+  - type: Sprite
+    sprite: Clothing/Back/Satchels/satchel.rsi
+  - type: SubFloorHide
+  - type: Anchorable
+  - type: Appearance
+  - type: Tag
+    tags: [] # ignore "WhitelistChameleon" tag
+
+# GoobStation - make smuggler's satchel stuck to ground
+- type: entity
+  parent: ClothingBackpackSatchelSmuggler
+  id: ClothingBackpackSatchelSmugglerAnchored
+  name: ранец
+  suffix: smugglers-anchored
+  components:
+  - type: Transform
+    anchored: true

--- a/Resources/Prototypes/_Evin/GameRules/events.yml
+++ b/Resources/Prototypes/_Evin/GameRules/events.yml
@@ -1,0 +1,28 @@
+# GoobStation - *spawns a random smuggler's satchel filled whit ligth contraband somwhere on the station
+- type: entity
+  id: SmugglerStashSpawnQuiet
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    weight: 10 # normal , its a little hige as its only one satchel, TODO: needs balancing
+    duration: 1
+    earliestStart: 0
+    reoccurrenceDelay: 20 # can happen evry 20 minutes
+    maxOccurrences: 0   #disabled
+  - type: RandomSpawnRule   #TODO make a new spawnrule for picking among different fills and spawning more at once. and make sure it only spawns under floorboards
+    prototype: ClothingBackpackSatchelSmugglerAnchoredFilled
+
+# GoobStation - not all smuggeling goes unnoticed
+- type: entity
+  id: SmugglerStashSpawn
+  parent: SmugglerStashSpawnQuiet
+  noSpawn: true
+  components:
+  - type: StationEvent
+    reoccurrenceDelay: 30
+    earliestStart: 15
+    startAnnouncement: station-event-smuggler-satchel-announcement
+    maxOccurrences: 3 #  3 is a  good nunber
+    startAudio:
+      path: /Audio/Announcements/attention.ogg


### PR DESCRIPTION
> #  Новый **Рюкзак контрабандиста**
Позволяет скрывать его под полом, от чужих глад. Увидеть его будучи в полу, можно только T-сканером.

> # Новое событие **Скрытое послание**
Спавнит рюкзак контрабандиста под полом на станции.

> # Респрайт Радио-аплинка 

> # Теперь Агосты могут носить перчатки и обувь

**Медиа**
![2024-06-26_22-09-15](https://github.com/CrimeMoot/space-evin-14/assets/169259387/0393e708-5afd-42d5-8f5b-922bdf9fbfc3)
![2024-06-26_22-09-08](https://github.com/CrimeMoot/space-evin-14/assets/169259387/c0c526f6-d584-4d41-adae-103d22035579)
![329801968-f732526e-dea0-40c8-9fbe-81f0fa2267cb](https://github.com/CrimeMoot/space-evin-14/assets/169259387/82295982-5bfd-4b51-aff9-d1786117af73)
![555](https://github.com/CrimeMoot/space-evin-14/assets/169259387/82fb8863-bf2c-41ec-be93-d5c22065c779)


**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

:cl:
- add: Рюкзак контрабандиста
- add: Игровое событие со спавном рюкзака
- add: Теперь Агосты могут носить перчатки и обувь
- add: Изменён спрайт Радио аплинка на планщет.
